### PR TITLE
Fix galaxy metadata

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: lablabs
 name: wireguard
-version: 0.1.1
+version: 0.2.4
 readme: README.md
 authors:
   - Labyrinth Labs <info@lablabs.io>
@@ -15,4 +15,3 @@ repository: https://github.com/lablabs/ansible-collection-wireguard
 documentation: https://github.com/lablabs/ansible-collection-wireguard
 homepage: https://www.lablabs.io
 issues: https://github.com/lablabs/ansible-collection-wireguard/issues
-build_ignore:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: lablabs
 name: wireguard
-version: 0.2.4
+version: "0.2.4"
 readme: README.md
 authors:
   - Labyrinth Labs <info@lablabs.io>
@@ -9,8 +9,8 @@ description: Wireguard Server Ansible Collection.
 license_file: LICENSE
 tags: [wireguard, vpn, system, linux, security, networking]
 dependencies:
-  devsec.hardening: 7.12.0
-  robertdebock.development_environment: 2.1.1
+  devsec.hardening: "7.12.0"
+  robertdebock.development_environment: "2.1.1"
 repository: https://github.com/lablabs/ansible-collection-wireguard
 documentation: https://github.com/lablabs/ansible-collection-wireguard
 homepage: https://www.lablabs.io


### PR DESCRIPTION
# Description

ansible-galaxy install for this collection is failing while upgrade from `0.2.2` to `0.2.3` with error
```
ERROR! Unexpected Exception, this is probably a bug: 'NoneType' object has no attribute 'items'
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Collection/Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
-
