### PR TITLE
fix: add empty dependencies list for wireguard role

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: lablabs
 name: wireguard
-version: "0.2.4"
+version: "0.2.6"
 readme: README.md
 authors:
   - Labyrinth Labs <info@lablabs.io>
@@ -9,8 +9,8 @@ description: Wireguard Server Ansible Collection.
 license_file: LICENSE
 tags: [wireguard, vpn, system, linux, security, networking]
 dependencies:
-  devsec.hardening: "==7.12.0"
-  robertdebock.development_environment: "==2.1.1"
+  devsec.hardening: "7.12.0"
+  robertdebock.development_environment: "2.1.1"
 repository: https://github.com/lablabs/ansible-collection-wireguard
 documentation: https://github.com/lablabs/ansible-collection-wireguard
 homepage: https://www.lablabs.io

--- a/roles/wireguard/meta/main.yml
+++ b/roles/wireguard/meta/main.yml
@@ -26,3 +26,4 @@ galaxy_info:
     - linux
     - vpn
     - wireguard
+  dependencies: []


### PR DESCRIPTION
# Description

Updating the ansible collection is failing with
```
ERROR! Unexpected Exception, this is probably a bug: 'NoneType' object has no attribute 'items'
```


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Collection/Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Local installation/upgrade of the collection
