### PR TITLE
Fix: Bump dependency versions

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: lablabs
 name: wireguard
-version: "0.3.1"
+version: "0.3.2"
 readme: README.md
 authors:
   - Labyrinth Labs <info@lablabs.io>
@@ -9,8 +9,8 @@ description: Wireguard Server Ansible Collection.
 license_file: LICENSE
 tags: [wireguard, vpn, system, linux, security, networking]
 dependencies:
-  devsec.hardening: "7.12.0"
-  robertdebock.roles: "1.9.7"
+  devsec.hardening: "8.7.0"
+  robertdebock.roles: "1.10.6"
 repository: https://github.com/lablabs/ansible-collection-wireguard
 documentation: https://github.com/lablabs/ansible-collection-wireguard
 homepage: https://www.lablabs.io


### PR DESCRIPTION
# Description

This bumps up the versions of the two dependencies to latest releases that contain several bugfixes, such as https://github.com/dev-sec/ansible-collection-hardening/issues/549 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Collection/Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?


Local testing using Vagrant against Rocky Linux 8 host
Roles `robertdebock.roles.fail2ban`, `devsec.hardening.ssh_hardening` & `devsec.hardening.os_hardening` have completed successfully.
 
Unable to test with Molecule due to issues with https://github.com/ansible-community/molecule/issues/2755


Pre-commit passed per the contributing guidelines:
```
Check Yaml...............................................................Passed
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
yamllint.................................................................Passed
Find unused variables in an Ansible role.................................Passed
Find empty files in an Ansible role......................................Passed
Find empty directories in an Ansible role................................Passed
Fix readability in Ansible role..........................................Passed
Find undefined handlers..................................................Passed
```