### PR TITLE
Fix: Use ansible package instead of ansible apt for heterogeneous environment 

### DIFF
--- a/playbooks/wireguard.yml
+++ b/playbooks/wireguard.yml
@@ -8,13 +8,28 @@
     - name: wireguard
 
   post_tasks:
-    - name: Install iptables-persistent
+    - name: Install iptables
       ansible.builtin.package:
         name:
           - iptables
-          - iptables-persistent
         state: present
 
+    - name: Install iptables-persistent for Debian family
+      ansible.builtin.package:
+        name:
+          - iptables-persistent
+        state: present
+      when: 
+        - ansible_os_family == "Debian"
+
+    - name: Install iptables-persistent for Redhat family
+      ansible.builtin.package:
+        name:
+          - iptables-services
+        state: present
+      when: 
+        - ansible_os_family == "RedHat"
+        
     - name: Setup MASQUERADE for server access through vpn server
       ansible.builtin.iptables:
         chain: POSTROUTING

--- a/playbooks/wireguard.yml
+++ b/playbooks/wireguard.yml
@@ -9,7 +9,7 @@
 
   post_tasks:
     - name: Install iptables-persistent
-      ansible.builtin.apt:
+      ansible.builtin.package:
         name:
           - iptables
           - iptables-persistent

--- a/playbooks/wireguard.yml
+++ b/playbooks/wireguard.yml
@@ -14,7 +14,6 @@
           - iptables
           - iptables-persistent
         state: present
-        update_cache: true
 
     - name: Setup MASQUERADE for server access through vpn server
       ansible.builtin.iptables:


### PR DESCRIPTION
# Description

On a Rocky system, the playbook fails due of usage of `ansible.builtin.apt` instead of `ansible.builtin.package`
```
TASK [Install iptables-persistent] *********************************************
[WARNING]: Updating cache and auto-installing missing dependency: python3-apt
fatal: [bastion]: FAILED! => {"changed": false, "cmd": "apt-get update", "msg": "[Errno 2] No such file or directory: b'apt-get': b'apt-get'", "rc": 2, "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
```

Additionally, iptables-persistent is only for Debian family and iptables-services is for Redhat family

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Collection/Role code (Github Actions Workflow, Documentation etc.)

## How Has This Been Tested?
Local testing using Vagrant against Rocky Linux 8 host
Main playbook has completed successfully.

Unable to test with Molecule due to issues with https://github.com/ansible-community/molecule/issues/2755